### PR TITLE
Fix credo warnings

### DIFF
--- a/lib/parse_torrent.ex
+++ b/lib/parse_torrent.ex
@@ -34,11 +34,9 @@ defmodule ParseTorrent do
 
   @spec parse(binary) :: {:ok, map} | :error
   def parse(data) do
-    try do
-      {:ok, parse!(data)}
+    {:ok, parse!(data)}
     rescue
       _e -> :error
-    end
   end
 
   @doc """

--- a/lib/parse_torrent.ex
+++ b/lib/parse_torrent.ex
@@ -19,8 +19,8 @@ defmodule ParseTorrent do
     pieces: []
   )
 
-  alias ParseTorrent.Error
   alias ParseTorrent, as: Torrent
+  alias ParseTorrent.Error
 
   @doc """
   Parses a torrent binary and returns a map.

--- a/mix.exs
+++ b/mix.exs
@@ -30,6 +30,7 @@ defmodule ParseTorrent.Mixfile do
   defp deps do
     [
       {:bencode, "0.3.2"},
+      {:credo, "~> 1.4", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.22.2", only: :dev, runtime: false}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,13 @@
 %{
   "bencode": {:hex, :bencode, "0.3.2", "1dece23710b54ef984852aa6abffac982e033eaaee8d57b6a6894ee8ddbd0c84", [:mix], [{:eqc_ex, "~> 1.2.4", [hex: :eqc_ex, repo: "hexpm", optional: false]}], "hexpm", "6abf5adace62d6e105b17d50faa8bdce84dea18c947ecb0bb81b6b2a3582dae7"},
   "bencodex": {:hex, :bencodex, "1.0.0"},
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
+  "credo": {:hex, :credo, "1.4.0", "92339d4cbadd1e88b5ee43d427b639b68a11071b6f73854e33638e30a0ea11f5", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "1fd3b70dce216574ce3c18bdf510b57e7c4c85c2ec9cad4bff854abaf7e58658"},
   "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.10", "6603d7a603b9c18d3d20db69921527f82ef09990885ed7525003c7fe7dc86c56", [:mix], [], "hexpm", "8e2d5370b732385db2c9b22215c3f59c84ac7dda7ed7e544d7c459496ae519c0"},
   "eqc_ex": {:hex, :eqc_ex, "1.2.4", "c169c4025e6f59d95977b1d5f3846cd964e996449755d7e9bf6ac6d3a4520839", [:mix], [], "hexpm", "2d2895bedf784ffaf11144d25e6ca11a4cfff5b73c35ec6bedd3c5ec5cabc5e9"},
   "ex_doc": {:hex, :ex_doc, "0.22.6", "0fb1e09a3e8b69af0ae94c8b4e4df36995d8c88d5ec7dbd35617929144b62c00", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "1e0aceda15faf71f1b0983165e6e7313be628a460e22a031e32913b98edbd638"},
+  "jason": {:hex, :jason, "1.2.2", "ba43e3f2709fd1aa1dce90aaabfd039d000469c05c56f0b8e31978e03fa39052", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "18a228f5f0058ee183f29f9eae0805c6e59d61c3b006760668d8d18ff0d12179"},
   "makeup": {:hex, :makeup, "1.0.3", "e339e2f766d12e7260e6672dd4047405963c5ec99661abdc432e6ec67d29ef95", [:mix], [{:nimble_parsec, "~> 0.5", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "2e9b4996d11832947731f7608fed7ad2f9443011b3b479ae288011265cdd3dad"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.1", "4f0e96847c63c17841d42c08107405a005a2680eb9c7ccadfd757bd31dabccfb", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "f2438b1a80eaec9ede832b5c41cd4f373b38fd7aa33e3b22d9db79e640cbde11"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.6.0", "32111b3bf39137144abd7ba1cce0914533b2d16ef35e8abc5ec8be6122944263", [:mix], [], "hexpm", "27eac315a94909d4dc68bc07a4a83e06c8379237c5ea528a9acff4ca1c873c52"},

--- a/test/parse_torrent_test.exs
+++ b/test/parse_torrent_test.exs
@@ -43,17 +43,17 @@ defmodule ParseTorrentTest do
       created_by: nil,
       files: [
         %{
-          length: 19211729,
+          length: 19_211_729,
           name: "bl001-introduction.webm",
           offset: 0,
           path: "bl001-introduction.webm"
         }
       ],
       info_hash: "4cb67059ed6bd08362da625b3ae77f6f4a075705",
-      last_piece_length: 337361,
-      length: 19211729,
+      last_piece_length: 337_361,
+      length: 19_211_729,
       name: "bl001-introduction.webm",
-      piece_length: 1048576,
+      piece_length: 1_048_576,
       pieces: [
         "90a75dcd4e88d287c7ac5599c108f6036c13c4ce",
         "1ef5468bdff9a4466ad4e446477981cb67d07933",
@@ -119,12 +119,12 @@ defmodule ParseTorrentTest do
         %{
           path: "Leaves of Grass by Walt Whitman.epub",
           name: "Leaves of Grass by Walt Whitman.epub",
-          length: 362017,
+          length: 362_017,
           offset: 0
         }
       ],
-      length: 362017,
-      piece_length: 16384,
+      length: 362_017,
+      piece_length: 16_384,
       last_piece_length: 1569,
       pieces: [
         "1f9c3f59beec079715ec53324bde8569e4a0b4eb",

--- a/test/parse_torrent_test.exs
+++ b/test/parse_torrent_test.exs
@@ -102,7 +102,7 @@ defmodule ParseTorrentTest do
     torrent = File.read!("test/torrents/leaves-url-list.torrent")
     |> ParseTorrent.parse!
 
-    assert torrent.url_list == [ "http://www2.hn.psu.edu/faculty/jmanis/whitman/leaves-of-grass6x9.pdf" ]
+    assert torrent.url_list == ["http://www2.hn.psu.edu/faculty/jmanis/whitman/leaves-of-grass6x9.pdf"]
   end
 
   test "parses single file torrent" do


### PR DESCRIPTION
This PR resolves all warnings raised by `mix credo --strict`.